### PR TITLE
Week 7 smart contract protocol: Course NFT Badge Creation and Airdrop

### DIFF
--- a/contributions/smart-contract-protocol/week7/shatan-runzec/README.md
+++ b/contributions/smart-contract-protocol/week7/shatan-runzec/README.md
@@ -1,0 +1,26 @@
+# Assignment Proposal
+
+## Title
+
+Course NFT Badge Creation and Airdrop
+
+## Names and KTH ID
+
+- Shangxuan Tang (shatan@kth.se)
+- Runze Cui (runzec@kth.se)
+
+## Deadline
+
+- Week 7
+
+## Category
+
+- Smart Contract Protocol
+
+## Description
+
+A Polygon-based Soulbound NFT badge system for the “Programmable Society” course. A fixed supply of 25 Programmable-Society (PSOC) NFTs is deployed on-chain and airdropped directly to collected student, TA, and teacher wallet addresses. 
+
+Each badge proves on-chain participation in the course, while roles (Student/TA/Teacher) are encoded off-chain in metadata and visuals. The badges are non-transferable, viewable in standard wallets and on OpenSea, and function as low-cost, publicly verifiable course credentials.
+
+Note: This credential is created solely as a course project demonstration of blockchain concepts and does not carry any formal or authoritative qualification value.


### PR DESCRIPTION
# Assignment Proposal

## Title

Course NFT Badge Creation and Airdrop

## Names and KTH ID

- Shangxuan Tang (shatan@kth.se)
- Runze Cui (runzec@kth.se)

## Deadline

- Week 7

## Category

- Smart Contract Protocol

## Description

A Polygon-based Soulbound NFT badge system for the “Programmable Society” course. A fixed supply of 25 Programmable-Society (PSOC) NFTs is deployed on-chain and airdropped directly to collected student, TA, and teacher wallet addresses. 

Each badge proves on-chain participation in the course, while roles (Student/TA/Teacher) are encoded off-chain in metadata and visuals. The badges are non-transferable, viewable in standard wallets and on OpenSea, and function as low-cost, publicly verifiable course credentials.

Note: This credential is created solely as a course project demonstration of blockchain concepts and does not carry any formal or authoritative qualification value.